### PR TITLE
Hide "Add Catgirl" button from character manager UI

### DIFF
--- a/templates/chara_manager.html
+++ b/templates/chara_manager.html
@@ -157,7 +157,7 @@
     <div class="section" id="catgirl-section">
         <div class="tips">🩷猫娘档案：进阶设定包含Live2D形象、语音ID等。</div>
         <div id="catgirl-list"></div>
-        <button class="btn add sm" id="add-catgirl-btn">➕ 新增猫娘</button>
+        <!-- <button class="btn add sm" id="add-catgirl-btn">➕ 新增猫娘</button> -->
     </div>
 </div>
 <script>


### PR DESCRIPTION
This update hides the "➕ Add Catgirl" button from the character manager interface.

This change may be useful for limiting character creation or enforcing constraints on the number of available catgirls.

No functionality beyond UI visibility has been altered.